### PR TITLE
Remove mkl depth causing error on creation of conda environment

### DIFF
--- a/cyclegan/environment.yml
+++ b/cyclegan/environment.yml
@@ -38,7 +38,6 @@ dependencies:
 - libxcb=1.13=h1bed415_1
 - libxml2=2.9.8=h26e45fe_1
 - matplotlib=3.0.0=py36h5429711_0
-- mkl=2019.0=118
 - mkl_fft=1.0.4=py36h4414c95_1
 - mkl_random=1.0.1=py36h4414c95_1
 - mpc=1.1.0=h10f8cd9_1

--- a/depthnet-pytorch/environment.yml
+++ b/depthnet-pytorch/environment.yml
@@ -38,7 +38,6 @@ dependencies:
 - libxcb=1.13=h1bed415_1
 - libxml2=2.9.8=h26e45fe_1
 - matplotlib=3.0.0=py36h5429711_0
-- mkl=2019.0=118
 - mkl_fft=1.0.4=py36h4414c95_1
 - mkl_random=1.0.1=py36h4414c95_1
 - mpc=1.1.0=h10f8cd9_1


### PR DESCRIPTION
@srajotte could I ask you to quickly test something for me? It's related to this issue here: https://github.com/joelmoniz/DepthNets/issues/8

If you create a conda environment like: `conda env create -f=environment.yml -n depthnet`,

does it work for you?

It works on my end on a fresh Ubuntu install, but I just want to double-check with someone else.

Cheers!